### PR TITLE
Add CI/CD

### DIFF
--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -22,6 +22,12 @@ jobs:
         cp result/resume/resume.html out/${{ github.actor}}_resume.html
         cp result/resume/resume.pdf out/${{ github.actor}}_resume.pdf
         cp result/resume/resume.md out/${{ github.actor}}_resume.md
+    - name: Validate HTML
+      run: |
+        html-validator --file=out/${{ github.actor}}_resume.html --verbose
+    - name: Validate PDF
+      run: |
+        pdfinfo out/${{ github.actor}}_resume.pdf
     - name: Store Artifacts
       uses: actions/upload-artifact@v4
       with:

--- a/README.md
+++ b/README.md
@@ -64,6 +64,15 @@ You can customize the stylized PDF and HTML output by editing `style.css`.
 ![demo](./demo.png)
 
 
+## Validation Process in CI/CD Pipeline
+
+The CI/CD pipeline includes validation steps to ensure the generated HTML and PDF files are properly formatted. The validation process is as follows:
+
+1. **HTML Validation**: The `html-validator-cli` tool is used to validate the generated HTML file. This ensures that the HTML file is properly formatted and adheres to web standards.
+2. **PDF Validation**: The `pdfinfo` tool from the `poppler-utils` package is used to validate the generated PDF file. This ensures that the PDF file is properly formatted and contains the expected content.
+
+These validation steps are included in the `generate` job of the GitHub Actions workflow (`.github/workflows/generate.yaml`).
+
 ## Credits
 
 Originally inspired by [vidluther's project](https://github.com/vidluther/markdown-resume).

--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,8 @@
         buildInputs = with pkgs; [
           pandoc
           wkhtmltopdf-bin
+          html-validator-cli
+          poppler-utils
         ];
 
         buildPhase = ''
@@ -31,6 +33,10 @@
           wkhtmltopdf --enable-local-file-access \
           resume.html \
           resume.pdf
+
+          html-validator --file=resume.html --verbose
+
+          pdfinfo resume.pdf
         '';
 
       in with pkgs; {
@@ -63,4 +69,3 @@
         };
       });
 }
-


### PR DESCRIPTION
Fixes #6

Add validation steps to CI/CD pipeline to check HTML and PDF formatting.

* **flake.nix**:
  - Add `html-validator-cli` and `poppler-utils` to `buildInputs`.
  - Update `buildPhase` to include validation steps for HTML and PDF.

* **.github/workflows/generate.yaml**:
  - Add a validation step in the `generate` job to check HTML and PDF formatting.
  - Use `html-validator-cli` for HTML validation.
  - Use `pdfinfo` for PDF validation.

* **README.md**:
  - Add documentation about the validation process in the CI/CD pipeline.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nkzarrabi/resume/pull/8?shareId=f5d710a3-1cf6-4fc4-ba36-e157c0c1f6d3).