### PR TITLE
Fix CSS validation errors in resume.html

### DIFF
--- a/style.css
+++ b/style.css
@@ -23,7 +23,7 @@ body {
 }
 
 body {
-    font: 13.34pxHelvetica;
+    font: 13.34px Helvetica, sans-serif;
     -webkit-font-smoothing: subpixel-antialiased;
     line-height: 1.4;
     padding: 3px;
@@ -39,7 +39,7 @@ p {
 
 a {
     color: #4183c4;
-    text-decoration: none
+    text-decoration: none;
 }
 
 body {
@@ -93,7 +93,7 @@ h2 {
 
 h3 {
     font-size: 18px;
-    color: #333
+    color: #333;
     -webkit-margin-before: 0.01em;
     -webkit-margin-after: 0.01em;
 }


### PR DESCRIPTION
Fixes #9

Fix CSS validation errors in `style.css`.

* Correct font property format to `font: 13.34px Helvetica, sans-serif;` at line 26.
* Add missing semicolon to `text-decoration` property at line 42.
* Add missing semicolon to `color` property at line 96.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nkzarrabi/resume/pull/10?shareId=84d42a4c-7a29-47af-99d0-c3258fe22c41).