### PR TITLE
Fix CI/CD pipeline

### DIFF
--- a/.github/workflows/generate.yaml
+++ b/.github/workflows/generate.yaml
@@ -21,8 +21,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v25
+      - uses: actions/checkout@v2
+      - uses: cachix/install-nix-action@v12
         with:
           github_access_token: ${{ secrets.GITHUB_TOKEN }}
       
@@ -52,7 +52,7 @@ jobs:
           pdfinfo out/${{ github.actor }}_resume.pdf
       
       - name: Store Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v2
         with:
           name: resume
           path: out/
@@ -63,10 +63,10 @@ jobs:
     if: github.ref == 'refs/heads/master'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v2
 
       - name: Retrieve Artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v2
         with:
           name: resume
           path: out/
@@ -76,7 +76,7 @@ jobs:
           mkdir public
           cp out/${{ github.actor }}_resume.html public/index.html
       - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+        uses: peaceiris/actions-gh-pages@v3.8.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public

--- a/README.md
+++ b/README.md
@@ -72,7 +72,18 @@ The CI/CD pipeline includes validation steps to ensure the generated HTML and PD
 2. **PDF Validation**: The `pdfinfo` tool from the `poppler-utils` package is used to validate the generated PDF file. This ensures that the PDF file is properly formatted and contains the expected content.
 
 These validation steps are included in the `generate` job of the GitHub Actions workflow (`.github/workflows/generate.yaml`).
-W.I.P
+
+### Updated GitHub Actions Workflow
+
+The GitHub Actions workflow has been updated to use the following versions of actions:
+
+- `actions/checkout@v2`
+- `cachix/install-nix-action@v12`
+- `actions/upload-artifact@v2`
+- `actions/download-artifact@v2`
+- `peaceiris/actions-gh-pages@v3.8.0`
+
+Please make sure to update your workflow file accordingly to ensure the CI/CD pipeline functions correctly.
 
 ## Credits
 


### PR DESCRIPTION
Fixes #11

Update GitHub Actions workflow to address CI/CD pipeline issues.

* **README.md**
  - Add a section to reflect the updated versions of actions used in the GitHub Actions workflow.

* **.github/workflows/generate.yaml**
  - Update `actions/checkout@v4` to `actions/checkout@v2`.
  - Update `cachix/install-nix-action@v25` to `cachix/install-nix-action@v12`.
  - Update `actions/upload-artifact@v4` to `actions/upload-artifact@v2`.
  - Update `actions/download-artifact@v4` to `actions/download-artifact@v2`.
  - Update `peaceiris/actions-gh-pages@v3` to `peaceiris/actions-gh-pages@v3.8.0`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/nkzarrabi/resume/pull/12?shareId=e365fd0f-31c3-4531-9997-0c3c9a642231).